### PR TITLE
Remove semicolon from template

### DIFF
--- a/src/Resources/skeleton/ddd/command-handler-test.tpl.php
+++ b/src/Resources/skeleton/ddd/command-handler-test.tpl.php
@@ -14,8 +14,8 @@ use Prophecy\PhpUnit\ProphecyTrait;
  *
  * @since <?= $version; ?><?= "\n"; ?>
  *
- * @covers \<?= $psr4Root; ?>\<?= $domain; ?>\Application\<?= $domain_namespace; ?><?= $extra["command_namespace"]; ?>\<?= $extra["command_namespace"]; ?>Command;
- * @covers \<?= $psr4Root; ?>\<?= $domain; ?>\Application\<?= $domain_namespace; ?><?= $extra["command_namespace"]; ?>\<?= $extra["command_namespace"]; ?>Handler;
+ * @covers \<?= $psr4Root; ?>\<?= $domain; ?>\Application\<?= $domain_namespace; ?><?= $extra["command_namespace"]; ?>\<?= $extra["command_namespace"]; ?>Command
+ * @covers \<?= $psr4Root; ?>\<?= $domain; ?>\Application\<?= $domain_namespace; ?><?= $extra["command_namespace"]; ?>\<?= $extra["command_namespace"]; ?>Handler
  */
 class <?= $class_name; ?> extends TestCase
 {


### PR DESCRIPTION
Semicolon is now removed from the command-handler-test.tpl.php template

Port to 2.x #15 