### PR TITLE
Add entitiy pre-fill to command handler

### DIFF
--- a/src/Resources/skeleton/ddd/command-handler.tpl.php
+++ b/src/Resources/skeleton/ddd/command-handler.tpl.php
@@ -13,11 +13,15 @@ use Becklyn\Ddd\Events\Domain\EventProvider;
  */
 class <?= $class_name; ?> extends CommandHandler
 {
+    private <?= $entity; ?>Repository $<?= $strtocamel($entity); ?>Repository;
+
     public function __construct (
-        private <?= $entity; ?>Repository $<?= $strtocamel($entity); ?>Repository,
+        <?= $entity; ?>Repository $<?= $strtocamel($entity); ?>Repository
+    ) {
+        $this->$<?= $strtocamel($entity); ?>Repository = $<?= $strtocamel($entity); ?>Repository;
 
         // TODO inject dependencies into <?= $class_name; ?>::__construct
-    ) {}
+    }
 
     public function handle (<?= $extra["command_namespace"]; ?>Command $command) : void
     {

--- a/src/Resources/skeleton/ddd/command-handler.tpl.php
+++ b/src/Resources/skeleton/ddd/command-handler.tpl.php
@@ -12,10 +12,11 @@ use Becklyn\Ddd\Events\Domain\EventProvider;
  */
 class <?= $class_name; ?> extends CommandHandler
 {
-    public function __construct ()
-    {
+    public function __construct (
+        private <?= $entity; ?>Repository $<?= $strtocamel($entity); ?>Repository,
+
         // TODO inject dependencies into <?= $class_name; ?>::__construct
-    }
+    ) {}
 
     public function handle (<?= $extra["command_namespace"]; ?>Command $command) : void
     {
@@ -27,6 +28,10 @@ class <?= $class_name; ?> extends CommandHandler
      */
     protected function execute ($command) : ?EventProvider
     {
+        $<?= $strtocamel($entity); ?> = $this-><?= $strtocamel($entity); ?>Repository->findOneById($command-><?= $strtocamel($entity); ?>Id());
+
         // TODO implement <?= $class_name; ?>::execute
+
+        return $<?= $strtocamel($entity); ?>;
     }
 }

--- a/src/Resources/skeleton/ddd/command-handler.tpl.php
+++ b/src/Resources/skeleton/ddd/command-handler.tpl.php
@@ -2,6 +2,7 @@
 
 namespace <?= $namespace; ?>;
 
+use <?= $psr4Root; ?>\<?= $domain; ?>\Domain\<?= $domain_namespace; ?><?= $entity; ?>Repository;
 use Becklyn\Ddd\Commands\Application\CommandHandler;
 use Becklyn\Ddd\Events\Domain\EventProvider;
 


### PR DESCRIPTION
Now the respective entity is pre-filled into the handle method of the command handler

Sample Code for a generated DestroyBookHandler:

```php
<?php declare(strict_types=1);

namespace App\Books\Application\DestroyBook;

use Becklyn\Ddd\Commands\Application\CommandHandler;
use Becklyn\Ddd\Events\Domain\EventProvider;

/**
 * @author Samuel Oechsler <so@becklyn.com>
 *
 * @since 2021-10-14
 */
class DestroyBookHandler extends CommandHandler
{
    public function __construct (
        private BookRepository $bookRepository,

        // TODO inject dependencies into DestroyBookHandler::__construct
    ) {}

    public function handle (DestroyBookCommand $command) : void
    {
        $this->handleCommand($command);
    }

    /**
     * @param DestroyBookCommand $command
     */
    protected function execute ($command) : ?EventProvider
    {
        $book = $this->bookRepository->findOneById($command->bookId());

        // TODO implement DestroyBookHandler::execute

        return $book;
    }
}
```

Closes #10 