### PR TITLE
Fix: Extended entity test traits

### DIFF
--- a/src/Resources/skeleton/ddd/entity-test-trait.tpl.php
+++ b/src/Resources/skeleton/ddd/entity-test-trait.tpl.php
@@ -65,7 +65,7 @@ trait <?= $class_name; ?><?= "\n"; ?>
     }
 
     protected function <?= $i18n["test"]["_given"]; ?><?= $entity; ?><?= $i18n["test"]["is_created"]; ?> (
-        ?<?= $entity; ?>Id $<?= $strtocamel($entity); ?>Id = null
+        ?<?= $entity; ?>Id $<?= $strtocamel($entity); ?>Id = null,
         // TODO add additional properties
     ) : <?= $entity; ?> {
         return <?= $entity; ?>::create(


### PR DESCRIPTION
Intentional usage of the PHP 8 syntax here.
In almost every case multiple parameters have to be added to this list.

Fix to: #21